### PR TITLE
Corrected lessons-dir definition.

### DIFF
--- a/build-workbook.rkt
+++ b/build-workbook.rkt
@@ -231,7 +231,7 @@
                             (= (length pspec) 3)
                             (string=? (first pspec) "exercise"))
                        (unless (file-exists? (build-path "pages" (regexp-replace #px"\\.scrbl$" (second pspec) ".pdf")))
-                         (copy-file (build-path (lessons-dir) (third pspec) (second pspec))
+                         (copy-file (build-path (lessons-dir) (third pspec) "exercises" (second pspec))
                                     (build-path "pages" (regexp-replace #px"\\.scrbl$" (second pspec) ".pdf"))))]
                       [else
                        (printf "Doing nothing for page ~a~n" pspec)

--- a/courses/algebra-pyret/resources/workbook/langs/en-us/backmatterlist-sols.rkt
+++ b/courses/algebra-pyret/resources/workbook/langs/en-us/backmatterlist-sols.rkt
@@ -1,0 +1,10 @@
+; This file specifies the pages that make up the unnumbered backmatter
+; for the workbook for the course containing this resources/workbook directory. 
+
+; This list should contain names of .pdf files that are in the pages directory.
+; Each list element must include a .pdf extension.
+
+; The backmatter will be generated from these pages in order
+
+("Contracts-Sols.pdf"
+)

--- a/courses/reactive/resources/workbook/langs/en-us/backmatterlist-sols.rkt
+++ b/courses/reactive/resources/workbook/langs/en-us/backmatterlist-sols.rkt
@@ -1,0 +1,10 @@
+; This file specifies the pages that make up the unnumbered backmatter
+; for the workbook for the course containing this resources/workbook directory. 
+
+; This list should contain names of .pdf files that are in the pages directory.
+; Each list element must include a .pdf extension.
+
+; The backmatter will be generated from these pages in order
+
+("Contracts-Sols.pdf"
+)

--- a/lib/paths.rkt
+++ b/lib/paths.rkt
@@ -13,7 +13,7 @@
 
 
 (define (lessons-dir)
-  (build-path "lessons"  "langs" (getenv "LANGUAGE")))
+  (build-path 'up "lessons"  "langs" (getenv "LANGUAGE")))
 
 (define-runtime-path lessons-dir-alt-eng
   (build-path 'up "lessons"  "langs" "en-us"))

--- a/lib/paths.rkt
+++ b/lib/paths.rkt
@@ -13,7 +13,7 @@
 
 
 (define (lessons-dir)
-  (build-path 'up "lessons"  "langs" (getenv "LANGUAGE")))
+  (build-path courses-base 'up "lessons"  "langs" (getenv "LANGUAGE")))
 
 (define-runtime-path lessons-dir-alt-eng
   (build-path 'up "lessons"  "langs" "en-us"))


### PR DESCRIPTION
The previous `lessons-dir` definition in `lib/paths.rkt` was causing a lot of scribble repeats. The table below is an informal indication of the speedup that fixing this provides. Even though I didn't average over many runs, the trend should be obvious. The columns show the times for the first and second (i.e., without cleaning) runs of `build-distrib`. Row 1 for times before the fix, row 2 for after.

```
        |  First run        |    Subsequent run
--------+-------------------|-------------------
        |                   |
Before  |  real 4m48.407s   |   real 3m54.740s
bugfix  |  user 3m17.022s   |   user 2m43.233s
        |  sys  0m45.508s   |   sys  0m39.497s
        |                   |
--------+-------------------+-------------------
        |                   |
After   |  real 1m45.915s   |   real 0m47.342s
bugfix  |  user 1m9.581s    |   user 0m28.686s
        |  sys  0m25.627s   |    sys 0m19.345s
        |                   |
--------^-------------------^-------------------
```
I notice that the attempt to avoid repetitions of `extract-PDF-pages` was deliberately nixed. I let that be, but it's possibly enabling that will provide more speedup.