### PR TITLE
Extra exercise PDFs made and linked to

### DIFF
--- a/build.rkt
+++ b/build.rkt
@@ -77,7 +77,7 @@
 (define (run-scribble scribble-file #:outfile (outfile #f)
                       #:never-generate-pdf? [never-generate-pdf? #f]
                       #:include-base-path? [include-base-path? #t])
-  
+
   (define output-dir
     (cond [(current-deployment-dir)
            ;; Rendering to a particular deployment directory.
@@ -96,24 +96,29 @@
                base)]))
   (define-values (base name dir?) (split-path scribble-file))
 
+  (define namestr (path->string name))
+
+  (when (scribble-again? namestr base output-dir)
   
-  (define output-path (build-path output-dir (string->path (regexp-replace #px"\\.scrbl$" (path->string name) ".html"))))
-  
-  (parameterize ([current-directory base]
-                 [current-namespace document-namespace]
-                 [current-document-output-path output-path])
-    (render (list (dynamic-require `(file ,(path->string name)) 'doc))
-            (if outfile (list outfile) (list name))
-            #:dest-dir output-dir
-            ;; Comment out next line to use default scribble.css file
-            #:style-file (build-path root-path "lib" "css-files-units" "scribble.css")
-            )
-    (when (and (not never-generate-pdf?) (current-generate-pdf?))
-      (translate-html-to-pdf
-       (build-path output-dir
-                   (regexp-replace #px".scrbl$"
-                                   (path->string name)
-                                   ".html")))))
+    (define output-path 
+      (build-path output-dir (string->path (regexp-replace #px"\\.scrbl$" namestr ".html"))))
+    
+    (parameterize ([current-directory base]
+                   [current-namespace document-namespace]
+                   [current-document-output-path output-path])
+      (render (list (dynamic-require `(file ,namestr) 'doc))
+              (if outfile (list outfile) (list name))
+              #:dest-dir output-dir
+              ;; Comment out next line to use default scribble.css file
+              #:style-file (build-path root-path "lib" "css-files-units" "scribble.css")
+              )
+      (when (and (not never-generate-pdf?) (current-generate-pdf?))
+        (translate-html-to-pdf
+         (build-path output-dir
+                     (regexp-replace #px".scrbl$"
+                                     namestr
+                                     ".html")))))
+  )
   (void))
 
 
@@ -310,7 +315,7 @@
                                                 "units"
                                                 subdir "exercises")])
           (unless (directory-exists? deploy-exercises-dir)
-            ; (unless (directory-exists? (build-path (current-deployment-dir) "courses" (current-course) (getenv "LANGUAGE") "units"))
+            ; (unless (directory-exists? (build-path (current-deployment-dir) "courses" (current-course) (getenv "LANGUAGE") "units")))
               
             (make-directory deploy-exercises-dir))
           
@@ -444,15 +449,16 @@
                                              ["es-mx" lessons-dir-alt-spa])
                                            lesson-name "exercises")]
                      [exer-deploy-dir (build-path (root-deployment-dir) "lessons" (getenv "LANGUAGE") lesson-name "exercises")])
-                (parameterize [(current-deployment-dir exer-dir)]
-                  (scribble-to-pdf exer-files exer-dir))
-                (for ([exerfile exer-files])
-                  (let* ([exerfile-pdf (regexp-replace #px"\\.scrbl$" exerfile ".pdf")]
-                         [exerfile-path (build-path exer-dir exerfile-pdf)])
-                    (copy-file exerfile-path
-                               (build-path exer-deploy-dir exerfile-pdf)
-                               #t)))
-                ))
+                (let ([fresh-pdfs-made?
+                        (parameterize [(current-deployment-dir exer-dir)]
+                          (scribble-to-pdf exer-files exer-dir))])
+                  (when fresh-pdfs-made?
+                    (for ([exerfile exer-files])
+                         (let* ([exerfile-pdf (regexp-replace #px"\\.scrbl$" exerfile ".pdf")]
+                                [exerfile-path (build-path exer-dir exerfile-pdf)])
+                           (copy-file exerfile-path
+                                      (build-path exer-deploy-dir exerfile-pdf)
+                                      #t)))))))
             pdf-lesson-exercises))
 
 
@@ -715,11 +721,15 @@
           (if (build-exercises?)
               (begin (build-exercise-handouts)
                      (workbook-styling-on)
-                     (build-extra-pdf-exercises))
+                     ;(build-extra-pdf-exercises)
+                           )
               (workbook-styling-on))
           )
         (textbook-styling-on)
         (update-resource-paths)
+        (workbook-styling-on)
+        (build-extra-pdf-exercises)
+        (textbook-styling-on)
         (build-course-units)
         (copy-resources)
         ))))

--- a/lib/scribble-pdf-helpers.rkt
+++ b/lib/scribble-pdf-helpers.rkt
@@ -7,13 +7,14 @@
          )
 
 (provide get-prog-cmd
+         scribble-again?
          scribble-files
 	 scribble-to-pdf)
 
 ; cross-platform helper for locating executables.  Looks for progname with and without .exe extension
 (define (get-prog-cmd progname)
  (let ([progpath (or (find-executable-path (string-append progname ".exe"))
-                     (find-executable-path progname) 
+                     (find-executable-path progname)
                      )])
    (if progpath progpath
        (error (format "Unable to find program ~a~n" progname)))))
@@ -39,7 +40,7 @@
 ;; determine whether a file needs to be re-scribbled either because
 ;; it was modified since its last scribbling or because the
 ;; css file was updated.
-;; scrbl-file is just <file>.scrbl; path is the dir containing that file 
+;; scrbl-file is just <file>.scrbl; path is the dir containing that file
 (define (scribble-again? scrbl-file path pagesdir)
   (let* ([fhtml (regexp-replace #px"\\.scrbl$" scrbl-file ".html")]
          [fhtmlpath (build-path pagesdir fhtml)])
@@ -54,36 +55,39 @@
 ;; wkbk-mod-sec could be #f if the previous workbook file is not available
 ;; 7/6/18 -- remove the wkbk-mod-sec parameter
 (define (scribble-files pages pagesdir extra-exercises-dir wkbk-mod-sec)
-  (for-each (lambda (f)
-              (cond
-                [(and (string? f) 
-                      (regexp-match #px".*\\.scrbl$" f)
-                      (scribble-again? f pagesdir pagesdir))
-                 (run-scribble (build-path pagesdir f))
-                 (let ([fhtml (regexp-replace #px"\\.scrbl$" f ".html")]
-                       [fpdf (regexp-replace #px"\\.scrbl$" f ".pdf")])
-                   ; -q option is for "quiet" operation
-                   (system* (get-prog-cmd "wkhtmltopdf") "--lowquality" "--print-media-type" "-q"
-                            (build-path pagesdir fhtml)
-                            (build-path pagesdir fpdf)))]
-                [(and (list? f) (= (length f) 3)
-                      (regexp-match #px".*\\.scrbl$" (second f))
-                      (scribble-again? (second f) (build-path extra-exercises-dir (third f) "exercises")
-                                       pagesdir)
-                      )
-                 (let ([exercise-dir (build-path extra-exercises-dir (third f) "exercises")])
-                   (run-scribble (build-path exercise-dir (second f)))
-                   (let ([fhtml (regexp-replace #px"\\.scrbl$" (second f) ".html")]
-                         [fpdf (regexp-replace #px"\\.scrbl$" (second f) ".pdf")])
+  (let ([scribble-ran? #f])
+    (for-each (lambda (f)
+                (cond
+                  [(and (string? f)
+                        (regexp-match #px".*\\.scrbl$" f)
+                        (scribble-again? f pagesdir pagesdir))
+                   (set! scribble-ran? #t)
+                   (run-scribble (build-path pagesdir f))
+                   (let ([fhtml (regexp-replace #px"\\.scrbl$" f ".html")]
+                         [fpdf (regexp-replace #px"\\.scrbl$" f ".pdf")])
                      ; -q option is for "quiet" operation
                      (system* (get-prog-cmd "wkhtmltopdf") "--lowquality" "--print-media-type" "-q"
                               (build-path pagesdir fhtml)
-                              (build-path pagesdir fpdf))))]
-                ))
-              pages))
+                              (build-path pagesdir fpdf)))]
+                  [(and (list? f) (= (length f) 3)
+                        (regexp-match #px".*\\.scrbl$" (second f))
+                        (scribble-again? (second f) (build-path extra-exercises-dir (third f) "exercises")
+                                         pagesdir))
+                   (set! scribble-ran? #f)
+                   (let ([exercise-dir (build-path extra-exercises-dir (third f) "exercises")])
+                     (run-scribble (build-path exercise-dir (second f)))
+                     (let ([fhtml (regexp-replace #px"\\.scrbl$" (second f) ".html")]
+                           [fpdf (regexp-replace #px"\\.scrbl$" (second f) ".pdf")])
+                       ; -q option is for "quiet" operation
+                       (system* (get-prog-cmd "wkhtmltopdf") "--lowquality" "--print-media-type" "-q"
+                                (build-path pagesdir fhtml)
+                                (build-path pagesdir fpdf))))]
+                  ))
+              pages)
+    scribble-ran?))
 
 ; Avoiding naming conflicts with the more general run-scribble
 ; function in the build script (shouldn't need two functions, but have never
 ; worked on merging them properly)
-(define (scribble-to-pdf pages pagesdir)   	
+(define (scribble-to-pdf pages pagesdir)
   (scribble-files pages pagesdir pagesdir #f))


### PR DESCRIPTION
Fix for #401.

Specifics:
- Have scribble-pdf-helpers.rkt provide `scribble-again?` for use in build.rkt.
- `scribble-files` and (therefore) `scribble-to-pdf` return a boolean -- true if any new files were created.
- build.rkt/run-scribble uses `scribble-again?` to avoid repeated scribbling.
- `build-extra-pdf-exercises` avoids repeated copying of PDFs.
- `build-extra-pdf-exercises` (with `workbook-styling-on`) called before `build-course-units` so latter can use its PDFs.