### PR TITLE
spaces in code; out-of-date warning

### DIFF
--- a/lib/bootstrap.css
+++ b/lib/bootstrap.css
@@ -248,6 +248,10 @@ div.codesexp       .studentAnswer+.studentAnswer { margin-left: 10px;}
   padding-right: 150px;
 }
 
+.circleevalsexp .hspace {
+  display: none;
+}
+
 /********************************************************************
  Print adjustments
  *********************************************************************/

--- a/lib/bootstraplesson.js
+++ b/lib/bootstraplesson.js
@@ -14,7 +14,17 @@ function isNewest() {
   // if it's not the current year or season, add the "obsolete" banner
   var url_current_year = url.indexOf(today_year) !== -1;
   var url_current_season = url_season == today_season;
+  var outOfDate = document.createElement('div');
+  outOfDate.setAttribute('id', 'outOfDate');
+  outOfDate.style.display = 'none';
+  var outOfDatePar = document.createElement('p');
+  outOfDatePar.innerText = 'These materials are OUT OF DATE! To get the latest version'
+    + ' of the materials, visit www.BootstrapWorld.org/materials';
+  outOfDate.appendChild(outOfDatePar);
+  var mainColumn = document.getElementsByClassName('maincolumn')[0];
+  mainColumn.insertBefore(outOfDate, mainColumn.childNodes[0]);
   if(!url_current_year || !url_current_season) {
+    outOfDate.style.display = 'fixed';
     console.warn("These materials are OUT OF DATE! To get the latest version"
       + " of the materials, visit www.BootstrapWorld.org/materials");
   }

--- a/lib/pretty-printing.css
+++ b/lib/pretty-printing.css
@@ -14,11 +14,12 @@ div.codesexp .expression {position: relative;}
 /*******************************************
   PrettyPrint Structured Output
   - style using float: left, to allow text-alignment flow
-  - everything has a left-padding of 10px, which provides spacing and indenting
+  - everything has a left-padding of 10px, which provides spacing and indenting --delete 
   - if an expr is wrapped, every element clears left
 */
 
-div.codesexp *, .replOutput > * {float: left; padding-left: 10px;}
+/* div.codesexp *, .replOutput > * {float: left; padding-left: 10px;} */
+div.codesexp *, .replOutput > * {float: left; padding-left: 0px;}
 .replOutput br{float: none;}
 .wrapped > * {clear: left;}
 

--- a/lib/process-code.rkt
+++ b/lib/process-code.rkt
@@ -44,6 +44,19 @@
 (define EXPR-HOLE-SYM2 'BSLeaveAHoleHere2)
 (define EXPR-HOLE-SYM3 'BSLeaveAHoleHere3)
 
+(define (intersperse-spaces args funargs?)
+  (define (intersperse-spaces-aux args)
+    (if (null? args) args
+        (let ([a (car args)] [d (cdr args)])
+          (if (null? d) (list a)
+              (cons a 
+                    (cons (hspace 1)
+                          (intersperse-spaces-aux d)))))))
+  (let ((ans (intersperse-spaces-aux args)))
+    (if (and funargs? (not (null? args)))
+        (cons (hspace 1) ans)
+        ans)))
+
 ;; converts sexp into structured markup
 ;; believe symbols only go to the first list case, not the symbol? case
 ;; recognizes EXPR-HOLE-SYM (used to create partially-completed expressions)
@@ -96,15 +109,15 @@
                         (elem #:style bs-closebrace-style ")")))]
            [else ;; have a function call
             (if (symbol? (first sexp))
-              (let ([args (map sexp->block/aux (rest sexp))])
+              (let ([args (intersperse-spaces (map sexp->block/aux (rest sexp)) 'args)])
                 (elem #:style bs-expression-style
                       (append
                        (list (elem #:style bs-openbrace-style "(") 
                              (elem #:style bs-operator-style 
-                                   (if (eq? (first sexp) EXPR-HOLE-SYM) " " (format "~a " (first sexp)))))
+                                   (if (eq? (first sexp) EXPR-HOLE-SYM) " " (format "~a" (first sexp)))))
                        args 
                        (list (elem #:style bs-closebrace-style ")")))))
-              (let ([parts (map sexp->block/aux sexp)])
+              (let ([parts (intersperse-spaces (map sexp->block/aux sexp) #f)])
                 (elem #:style bs-expression-style
                       (append
                        (list (elem #:style bs-openbrace-style "("))


### PR DESCRIPTION
- Have actual spaces (actually nbsps) separating subforms rather than CSS. This fixes #430.
- Have an out-of-date warning `<div>` at the head of every lesson. Its `display` is set or not as appropriate.